### PR TITLE
Improve output formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gruntplugin"
   ],
   "dependencies": {
+    "log-symbols": "1.0.2",
     "symdiff": "0.0.2"
   }
 }

--- a/tasks/symdiff.js
+++ b/tasks/symdiff.js
@@ -75,22 +75,22 @@ module.exports = function(grunt) {
         var diff = symdiff(cssClasses, tplClasses, options.ignore);
 
         ['CSS', 'Templates'].forEach(function(type) {
-          var result = diff[type.toLowerCase()];
+            var result = diff[type.toLowerCase()];
 
-          // `✔ Templates` in green
-          var string = [symbols.success, type ['green']];
+            // `✔ Templates` in green
+            var string = [symbols.success, type ['green']];
 
-          if (result.length) {
-            // TODO: add better formatting and separation of class names, currently just a long comma-separated list
-            // `✖ CSS slider-slides, ...` in red
-            string = [symbols.error, type ['red'], result.join(' ')];
-          }
+            if (result.length) {
+                // TODO: add better formatting and separation of class names, currently just a long comma-separated list
+                // `✖ CSS slider-slides, ...` in red
+                string = [symbols.error, type ['red'], result.join(' ')];
+            }
 
-          grunt.log.writeln.apply(this, string);
+            grunt.log.writeln.apply(this, string);
         });
 
         if (diff.css.length || diff.templates.length) {
-          grunt.fail.warn('symdiff encountered unused classes', '\n');
+            grunt.fail.warn('symdiff encountered unused classes', '\n');
         }
     });
 

--- a/tasks/symdiff.js
+++ b/tasks/symdiff.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var symdiff = require('symdiff');
+var symbols = require('log-symbols');
 
 function dedup(t, idx, arr) {
     return arr.lastIndexOf(t) === idx;
@@ -72,11 +73,24 @@ module.exports = function(grunt) {
 
         // calculate the result
         var diff = symdiff(cssClasses, tplClasses, options.ignore);
-        if (diff.css.length) {
-            grunt.fail.warn('Unused CSS classes: ' + diff.css.join(' ') + '\n');
-        }
-        if (diff.templates.length) {
-            grunt.fail.warn('Unused template classes: ' + diff.templates.join(' ') + '\n');
+
+        ['CSS', 'Templates'].forEach(function(type) {
+          var result = diff[type.toLowerCase()];
+
+          // `✔ Templates` in green
+          var string = [symbols.success, type ['green']];
+
+          if (result.length) {
+            // TODO: add better formatting and separation of class names, currently just a long comma-separated list
+            // `✖ CSS slider-slides, ...` in red
+            string = [symbols.error, type ['red'], result.join(' ')];
+          }
+
+          grunt.log.writeln.apply(this, string);
+        });
+
+        if (diff.css.length || diff.templates.length) {
+          grunt.fail.warn('symdiff encountered unused classes', '\n');
         }
     });
 


### PR DESCRIPTION
It also fixes a bug that caused only the CSS unused classes to be shown, even though there might also be template unused classes.

``` sh
✖ CSS slider-slides ...

✔ Templates
Warning: symdiff encountered unused classes Use --force to continue.

Aborted due to warnings.
```

Particular bad project output example:
![screen shot 2015-05-13 at 16 37 54](https://cloud.githubusercontent.com/assets/938453/7606791/980607be-f98e-11e4-9588-3d7c7d401163.png)
